### PR TITLE
Add Windows setup instructions for dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ Kho lưu trữ này cung cấp một quy trình gọn nhẹ để kiểm soát c
    source .venv/bin/activate
    pip install -r requirements.txt
    ```
+   ```powershell
+   python -m venv .venv
+   .venv\Scripts\Activate.ps1  # Dùng .venv\Scripts\Activate.bat nếu chạy trong Command Prompt
+   pip install -r requirements.txt
+   ```
+   Người dùng Windows hãy chọn khối lệnh phù hợp với shell mà mình đang sử dụng.
 
 2. **Chuẩn bị dữ liệu đầu vào**
    * Đặt các ảnh quét CRF theo từng trang (PNG hoặc JPG) trong `data/scans/`. Nếu nguồn ban đầu là PDF, hãy dùng `scripts/ocr_pdf_to_images.py` để kết xuất thành ảnh.


### PR DESCRIPTION
## Summary
- add a Windows PowerShell variant of the dependency setup commands in the README
- note that Windows users should pick the block for their active shell

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0004b3924833086ab100e45361662